### PR TITLE
Add physics unit length, fix freeze sprite issues and simplify movement

### DIFF
--- a/src/animation/components.rs
+++ b/src/animation/components.rs
@@ -30,27 +30,27 @@ pub enum DefaultAnimations {
 }
 
 impl DefaultAnimations {
-    pub fn from(
-        direction: MovementDirection,
-        player_animations: DefaultAnimations,
-    ) -> DefaultAnimations {
-        let player_animation_from_current_direction = match direction {
+    /** Updates animation direction when movement direction changes */
+    pub fn update_based_on_movement(&mut self, direction: &MovementDirection) {
+        let new_animation = match direction {
             MovementDirection::Up => DefaultAnimations::WalkUp,
             MovementDirection::Down => DefaultAnimations::WalkDown,
             MovementDirection::Left => DefaultAnimations::WalkLeft,
             MovementDirection::Right => DefaultAnimations::WalkRight,
             MovementDirection::None => {
                 // If the player is not moving, map the current walking animation to the corresponding idle animation
-                match player_animations {
+                match *self {
                     DefaultAnimations::WalkUp => DefaultAnimations::IdleUp,
                     DefaultAnimations::WalkDown => DefaultAnimations::IdleDown,
                     DefaultAnimations::WalkLeft => DefaultAnimations::IdleLeft,
                     DefaultAnimations::WalkRight => DefaultAnimations::IdleRight,
-                    _ => player_animations, // If already idle, keep the current animation
+                    _ => *self, // If already idle, keep the current animation
                 }
             }
         };
-        player_animation_from_current_direction
+
+        // Update the animation state
+        *self = new_animation;
     }
 }
 
@@ -147,10 +147,10 @@ impl Default for DefaultAnimationConfig {
 }
 
 impl DefaultAnimationConfig {
-    pub fn get_indices(&self, state: DefaultAnimations) -> AnimationIndices {
+    pub fn get_indices(&self, state: &DefaultAnimations) -> AnimationIndices {
         let animation_data = self
             .animations
-            .get(&state)
+            .get(state)
             .unwrap_or_else(|| panic!("Missing animation data for {:?}", state));
 
         let first = animation_data.row * self.columns;
@@ -159,10 +159,10 @@ impl DefaultAnimationConfig {
         AnimationIndices { first, last }
     }
 
-    pub fn get_timer(&self, state: DefaultAnimations) -> Timer {
+    pub fn get_timer(&self, state: &DefaultAnimations) -> Timer {
         let animation_data = self
             .animations
-            .get(&state)
+            .get(state)
             .unwrap_or_else(|| panic!("Missing animation data for {:?}", state));
 
         Timer::from_seconds(animation_data.frame_duration, TimerMode::Repeating)

--- a/src/animation/update_default_animations.rs
+++ b/src/animation/update_default_animations.rs
@@ -6,31 +6,24 @@ use super::{DefaultAnimationConfig, DefaultAnimations, MovementDirection};
 
 pub fn update_animation_on_movement_direction_change(
     animation_config: Res<DefaultAnimationConfig>,
-    mut query: Query<
+    mut animated_query: Query<
         (
-            &mut AnimationIndices,
             &MovementDirection,
+            &mut AnimationIndices,
             &mut DefaultAnimations,
             &mut AnimationTimer,
             &mut Sprite,
         ),
-        (With<DefaultAnimations>, Changed<MovementDirection>),
+        Changed<MovementDirection>,
     >,
 ) {
-    if let Ok((mut indices, movement_direction, mut animations, mut timer, mut sprite)) =
-        query.get_single_mut()
+    for (movement_direction, mut indices, mut animations, mut timer, mut sprite) in
+        animated_query.iter_mut()
     {
-        let animation_from_current_direction =
-            DefaultAnimations::from(*movement_direction, *animations);
+        animations.update_based_on_movement(movement_direction);
 
-        if *animations == animation_from_current_direction {
-            warn!("Skipping redundant animation update");
-            return;
-        }
-
-        *animations = animation_from_current_direction;
-        *indices = animation_config.get_indices(animation_from_current_direction);
-        *timer = AnimationTimer(animation_config.get_timer(animation_from_current_direction));
+        *indices = animation_config.get_indices(&animations);
+        *timer = AnimationTimer(animation_config.get_timer(&animations));
         if let Some(atlas) = &mut sprite.texture_atlas {
             atlas.index = indices.first;
         }

--- a/src/combat/status_effects/status_systems/frozen.rs
+++ b/src/combat/status_effects/status_systems/frozen.rs
@@ -5,15 +5,16 @@ use crate::{
         components::{FrozenStatus, StatusType},
         events::ApplyStatus,
     },
-    configuration::assets::SpriteAssets,
     despawn::components::LiveDuration,
 };
+
+const BLUE_COLOR: bevy::prelude::Color = Color::srgb(0.0, 0.0, 1.0);
 
 pub fn on_frozen_applied(
     trigger: Trigger<OnInsert, FrozenStatus>,
     mut commands: Commands,
     status_query: Query<(&Parent, &LiveDuration), With<FrozenStatus>>,
-    sprites: Res<SpriteAssets>,
+    mut parent_sprite: Query<&mut Sprite>,
 ) {
     let Ok((parent, duration)) = status_query.get(trigger.entity()) else {
         return;
@@ -27,22 +28,21 @@ pub fn on_frozen_applied(
         parent.get(),
     );
 
-    commands
-        .entity(parent.get())
-        .insert(Sprite::from_image(sprites.merman_enemy.clone()));
+    if let Ok(mut parent_sprite) = parent_sprite.get_mut(parent.get()) {
+        parent_sprite.color = BLUE_COLOR;
+    }
 }
 
 pub fn on_frozen_removed(
     trigger: Trigger<OnRemove, FrozenStatus>,
-    mut commands: Commands,
     status_query: Query<&Parent, With<FrozenStatus>>,
-    sprites: Res<SpriteAssets>,
+    mut parent_sprite: Query<&mut Sprite>,
 ) {
     let Ok(parent) = status_query.get(trigger.entity()) else {
         return;
     };
 
-    commands
-        .entity(parent.get())
-        .insert(Sprite::from_image(sprites.merman_enemy.clone()));
+    if let Ok(mut parent_sprite) = parent_sprite.get_mut(parent.get()) {
+        parent_sprite.color = Color::default();
+    }
 }

--- a/src/configuration/setup.rs
+++ b/src/configuration/setup.rs
@@ -35,7 +35,10 @@ impl Plugin for SetupPlugin {
 
         app
             // setup avian physics (used for forces, collision, etc...)
-            .add_plugins(PhysicsPlugins::default())
+            // length unit here represents "pixels per meter" and is a way to indicate the
+            // scale of your world to the physics engine for performance optimizations
+            // In this case, our tiles are currently 32 x 32 pixels so we set the scale accordingly
+            .add_plugins(PhysicsPlugins::default().with_length_unit(32.0))
             .insert_resource(GameProgress::default())
             .insert_resource(Gravity::ZERO) // no gravity since this is top-down game
             // initialize states

--- a/src/enemy/systems/enemy_spawn.rs
+++ b/src/enemy/systems/enemy_spawn.rs
@@ -72,15 +72,15 @@ fn spawn_enemy(
             TextureAtlas {
                 layout: atlases.enemy_atlas_layout.clone(),
                 index: animation_config
-                    .get_indices(DefaultAnimations::IdleDown)
+                    .get_indices(&DefaultAnimations::IdleDown)
                     .first,
             },
         );
 
         //Todo move to setup file / trigger / something besides bloating this
         commands.entity(new_enemy).insert((
-            animation_config.get_indices(DefaultAnimations::IdleDown),
-            AnimationTimer(animation_config.get_timer(DefaultAnimations::IdleDown)),
+            animation_config.get_indices(&DefaultAnimations::IdleDown),
+            AnimationTimer(animation_config.get_timer(&DefaultAnimations::IdleDown)),
             sprite,
             DefaultAnimations::IdleDown,
             MovementDirection::None,

--- a/src/movement/motion.rs
+++ b/src/movement/motion.rs
@@ -3,9 +3,11 @@ use bevy::prelude::*;
 
 use crate::{animation::MovementDirection, movement::components::SimpleMotion};
 
-pub fn simple_movement_to_velocity(mut query: Query<(&SimpleMotion, &mut LinearVelocity)>) {
-    for (motion, mut velocity) in query.iter_mut() {
-        if motion.can_move {
+pub fn simple_movement_to_velocity(
+    mut query: Query<(&SimpleMotion, &MovementDirection, &mut LinearVelocity)>,
+) {
+    for (motion, move_direction, mut velocity) in query.iter_mut() {
+        if motion.can_move && *move_direction != MovementDirection::None {
             let temp_vel = motion.get_velocity();
             velocity.x = temp_vel.x;
             velocity.y = temp_vel.y;
@@ -20,11 +22,12 @@ pub fn update_movement_direction_on_motion_change(
     mut query: Query<(&SimpleMotion, &mut MovementDirection), Changed<SimpleMotion>>,
 ) {
     for (motion, mut movement_direction) in query.iter_mut() {
-        if motion.can_move == false {
-            movement_direction.set_if_neq(MovementDirection::None);
-            continue; // Add early return to prevent the next line from executing
-        }
-        let new_direction = MovementDirection::from_vec2(motion.direction);
-        movement_direction.set_if_neq(new_direction);
+        let new_directon = if motion.can_move == false {
+            MovementDirection::None
+        } else {
+            MovementDirection::from_vec2(motion.direction)
+        };
+
+        movement_direction.set_if_neq(new_directon);
     }
 }

--- a/src/player/animation/animation_setup.rs
+++ b/src/player/animation/animation_setup.rs
@@ -18,15 +18,15 @@ pub fn set_starting_player_animation_and_sprite_sheet(
         TextureAtlas {
             layout: atlases.player_atlas_layout.clone(),
             index: animation_config
-                .get_indices(DefaultAnimations::IdleDown)
+                .get_indices(&DefaultAnimations::IdleDown)
                 .first,
         },
     );
 
     if let Ok(player) = query.get_single_mut() {
         commands.entity(player).insert((
-            animation_config.get_indices(DefaultAnimations::IdleDown),
-            AnimationTimer(animation_config.get_timer(DefaultAnimations::IdleDown)),
+            animation_config.get_indices(&DefaultAnimations::IdleDown),
+            AnimationTimer(animation_config.get_timer(&DefaultAnimations::IdleDown)),
             sprite,
         ));
     }

--- a/src/player/systems/movement.rs
+++ b/src/player/systems/movement.rs
@@ -2,6 +2,7 @@ use avian2d::prelude::LinearVelocity;
 use bevy::prelude::*;
 
 use crate::{
+    animation::MovementDirection,
     map::WorldSpaceConfig,
     movement::components::SimpleMotion,
     player::{
@@ -17,17 +18,15 @@ pub fn player_movement(
     let mut motion = player_motion_query.into_inner();
     for event in event_reader.read() {
         motion.direction = event.direction;
-        motion.can_move = true;
     }
 }
 
 //Fires once the player has stopped moving
 pub fn on_player_stopped(
     _: Trigger<PlayerStoppedEvent>,
-    mut motion_query: Query<&mut SimpleMotion, With<Player>>,
+    movement_direction: Single<&mut MovementDirection, With<Player>>,
 ) {
-    let mut motion = motion_query.single_mut();
-    motion.can_move = false;
+    *movement_direction.into_inner() = MovementDirection::None;
 }
 
 // System to keep player within map bounds


### PR DESCRIPTION
* Adds physics unit length to speed up physics engine
* Simplified translation from MovementDirection to DefaultAnimations
* Resolves need for redundant "animation hasn't changed" check, does not panic
* update_animation_on_movement_direction_change now loops over all animations that meet criteria
* Frozen enemies now are colored blue rather than switching to mermen, resolving #15 
* Enemy movement function has been greatly simplified, general movement functions are handling most of this now
* can_move is no longer used for enemy or player movement.
    * it is only used when we want to "lock" movement so we use it for NPC and stun